### PR TITLE
Highlight vimrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
                     ".gvim",
                     ".ideavim"
                 ],
+                "filenames": [
+                    "vimrc"
+                ],
                 "configuration": "./language-configuration.json"
             }
         ],


### PR DESCRIPTION
Vim supports a configuration file in `~/.vim/vimrc`. This should also be highlighted.