### PR TITLE
update first line of README to enable better search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/dunstontc.viml.svg?style=flat&color=blue)](https://marketplace.visualstudio.com/items?itemName=dunstontc.viml) -->
 
 ## Features
-- Syntax highlighting for .vim files.
+- Syntax highlighting for Vim config files like `.vim` and `.vimrc`.
 - By default, the following file(types) will be highlighted:
   - `*.vim`
   - `*.vimrc`
@@ -13,4 +13,3 @@
   - `*.ideavim`
 
 ## [License](https://github.com/dunstontc/viml/blob/master/LICENSE)
-


### PR DESCRIPTION
I searched for `vimrc` inside the VS Code extension store but didn't get this extension in the search results. 

Seems like search inside the extensions store uses the description text of the extension, which comes from the first line of the `README`.

I eventually found the extension after opening [an issue with VS Code](https://github.com/Microsoft/vscode/issues/70121). 

PR so that hopefully more people find the extension!

<img width="728" alt="Screen Shot 2019-03-09 at 10 15 50 AM" src="https://user-images.githubusercontent.com/11388735/54073449-3a57d980-4255-11e9-8afa-603176dd9f0e.png">